### PR TITLE
comit de testes na branch de exemplo

### DIFF
--- a/test/user.test.js
+++ b/test/user.test.js
@@ -1,0 +1,73 @@
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const app = require('../api/index'); // Importa o app da API
+const { expect } = chai;
+const request = require('supertest');
+
+chai.use(chaiHttp);
+
+describe('Testes da API de Usuários', () => {
+  // Teste para a rota GET /users
+  it('Deve retornar todos os usuários', (done) => {
+    request(app)
+      .get('/users')
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).to.be.an('array');
+        expect(res.body.length).to.be.equal(2); // Espera que haja 2 usuários
+        done();
+      });
+  });
+
+  // Teste para a rota GET /users/:id
+  it('Deve retornar um usuário específico pelo ID', (done) => {
+    request(app)
+      .get('/users/1')
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('id', 1);
+        expect(res.body).to.have.property('name', 'João da Silva');
+        done();
+      });
+  });
+
+  // Teste para a rota POST /users
+  it('Deve criar um novo usuário', (done) => {
+    const newUser = { name: 'Carlos Pereira', email: 'carlos@example.com' };
+    request(app)
+      .post('/users')
+      .send(newUser)
+      .end((err, res) => {
+        expect(res).to.have.status(201);
+        expect(res.body).to.have.property('id');
+        expect(res.body).to.have.property('name', 'Carlos Pereira');
+        expect(res.body).to.have.property('email', 'carlos@example.com');
+        done();
+      });
+  });
+
+  // Teste para a rota PUT /users/:id
+  it('Deve atualizar um usuário existente', (done) => {
+    const updatedUser = { name: 'João Atualizado', email: 'joaoatualizado@example.com' };
+    request(app)
+      .put('/users/1')
+      .send(updatedUser)
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).to.have.property('name', 'João Atualizado');
+        expect(res.body).to.have.property('email', 'joaoatualizado@example.com');
+        done();
+      });
+  });
+
+  // Teste para a rota DELETE /users/:id
+  it('Deve excluir um usuário', (done) => {
+    request(app)
+      .delete('/users/1')
+      .end((err, res) => {
+        expect(res).to.have.status(204);
+        done();
+      });
+  });
+});


### PR DESCRIPTION
Descrição: Este Pull Request adiciona uma suíte de testes automatizados para a API de Usuários utilizando as bibliotecas Chai, Chai-HTTP e Supertest. Os testes cobrem as principais rotas da API, garantindo que as funcionalidades de CRUD (Create, Read, Update, Delete) estejam funcionando corretamente.

Principais mudanças:

    Adiciona testes para a rota GET /users que verifica se todos os usuários são retornados corretamente.
    Adiciona testes para a rota GET /users/:id que verifica se um usuário específico é retornado com base no ID.
    Adiciona testes para a rota POST /users que verifica a criação de um novo usuário.
    Adiciona testes para a rota PUT /users/:id que verifica a atualização de um usuário existente.
    Adiciona testes para a rota DELETE /users/:id que verifica a exclusão de um usuário.

Detalhes dos testes:

    GET /users: Verifica se a resposta contém um array de usuários e se o número de usuários é igual a 2.
    GET /users/:id: Verifica se a resposta contém o usuário correto com base no ID fornecido.
    POST /users: Verifica se um novo usuário é criado corretamente e se os dados retornados estão corretos.
    PUT /users/:id: Verifica se um usuário existente é atualizado corretamente.
    DELETE /users/:id: Verifica se um usuário é excluído corretamente e se o status de resposta é 204.

Motivação: A adição desses testes automatizados é essencial para garantir a integridade e a confiabilidade da API de Usuários. Com esses testes, podemos detectar rapidamente qualquer regressão ou problema nas funcionalidades de CRUD.

Como testar:

    Instale as dependências necessárias com npm install.
    Execute os testes com o comando npm test ou mocha (dependendo da configuração do projeto).
    Verifique se todos os testes passam com sucesso.

Dependências:

    chai
    chai-http
    supertest

Notas adicionais:

    Certifique-se de que o servidor da API esteja rodando corretamente antes de executar os testes.
    O número de usuários esperado no teste GET /users é 2, conforme os dados de exemplo.
